### PR TITLE
build_image: Allow disabling custom inode count calculation

### DIFF
--- a/tools/releasetools/build_image.py
+++ b/tools/releasetools/build_image.py
@@ -273,7 +273,7 @@ def BuildImageMkfs(in_dir, prop_dict, out_file, target_out, fs_config):
       base_fs_file = ConvertBlockMapToBaseFs(prop_dict["base_fs_file"])
       build_command.extend(["-d", base_fs_file])
     build_command.extend(["-L", prop_dict["mount_point"]])
-    if "extfs_inode_count" in prop_dict:
+    if "extfs_inode_count" in prop_dict and int(prop_dict["extfs_inode_count"]) >= 0:
       build_command.extend(["-i", prop_dict["extfs_inode_count"]])
     if "extfs_rsv_pct" in prop_dict:
       build_command.extend(["-M", prop_dict["extfs_rsv_pct"]])
@@ -459,19 +459,20 @@ def BuildImage(in_dir, prop_dict, out_file, target_out=None):
           size = common.RoundUpTo4K(size)
         else:
           size = ((size + block_size - 1) // block_size) * block_size
-      extfs_inode_count = prop_dict["extfs_inode_count"]
-      inodes = int(fs_dict.get("Inode count", extfs_inode_count))
-      inodes -= int(fs_dict.get("Free inodes", "0"))
-      # add .2% margin or 1 inode, whichever is greater
-      spare_inodes = inodes * 2 // 1000
-      min_spare_inodes = 1
-      if spare_inodes < min_spare_inodes:
-        spare_inodes = min_spare_inodes
-      inodes += spare_inodes
-      prop_dict["extfs_inode_count"] = str(inodes)
+      if int(prop_dict["extfs_inode_count"]) >= 0:
+        extfs_inode_count = prop_dict["extfs_inode_count"]
+        inodes = int(fs_dict.get("Inode count", extfs_inode_count))
+        inodes -= int(fs_dict.get("Free inodes", "0"))
+        # add .2% margin or 1 inode, whichever is greater
+        spare_inodes = inodes * 2 // 1000
+        min_spare_inodes = 1
+        if spare_inodes < min_spare_inodes:
+          spare_inodes = min_spare_inodes
+        inodes += spare_inodes
+        prop_dict["extfs_inode_count"] = str(inodes)
+        logger.info(
+            "Allocating %d Inodes for %s.", inodes, out_file)
       prop_dict["partition_size"] = str(size)
-      logger.info(
-          "Allocating %d Inodes for %s.", inodes, out_file)
     if verity_image_builder:
       size = verity_image_builder.CalculateDynamicPartitionSize(size)
     prop_dict["partition_size"] = str(size)


### PR DESCRIPTION
This allows us to skip custom inode count calculation by setting
BOARD_*IMAGE_EXTFS_INODE_COUNT to -1, this will end up letting
mke2fs calculate appropriate inode count on its own.

While build_image only allocates exact number of needed inodes
plus 4% spare with .2% margin, mke2fs will allocate as many
inodes as it thinks is appropriate given the filesystem size.

Change-Id: If03d5edae8378be3b305346176067b01163f6f3d